### PR TITLE
Reflect gradle jar output file accurately in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Channels can be extended to major brokers like Kafka or RabbitMQ, so Transport b
 ./gradlew jar
 ```
 
-The file is output to `lib/build/libs/transport-1.0.0.jar`
+The file is output to `lib/build/libs/transport-1.0.0-SNAPSHOT.jar`
 
 ### [Read More Java Documentation](https://vmware.github.io/transport/java)
 


### PR DESCRIPTION
After build config update the artifacts will now be postfixed with
their buildType either -SNAPSHOT or -RELEASE. By default -SNAPSHOT
will be appended if no override of buildType is provided.

Signed-off-by: Josh Kim <kjosh@vmware.com>